### PR TITLE
Removing empty params

### DIFF
--- a/schema/rcif/cmd.jsonnet
+++ b/schema/rcif/cmd.jsonnet
@@ -46,9 +46,6 @@ local cs = {
                 doc="Interval between triggers in 16 ns time ticks (default 1.024 s)"),
     ]),
 
-    empty_params: s.record("EmptyParams", [
-    ])
-
 
 };
 


### PR DESCRIPTION
The need for emptypars has been removed by declaring the `AddressedCmd` `data` filed optional in `appfwk`