### PR TITLE
Added a field to the StartParams schema to indicate PROD vs. TEST

### DIFF
--- a/schema/rcif/cmd.jsonnet
+++ b/schema/rcif/cmd.jsonnet
@@ -39,7 +39,8 @@ local cs = {
     start_params: s.record("StartParams", [
         s.field("run", self.run_number, doc="Run Number"),
         s.field("disable_data_storage", self.disable_storage, 0, doc="Bool to disable storage. True = storage disabled"),
-        s.field("trigger_rate", self.trg_rate, doc="Generated fake trigger rate Hz.", optional=true)
+        s.field("trigger_rate", self.trg_rate, doc="Generated fake trigger rate Hz.", optional=true),
+        s.field("production_vs_test", self.state, "TEST", doc="Indicator of Production vs. Test running.")
     ]),
 
     change_rate_params: s.record("ChangeRateParams", [


### PR DESCRIPTION
This new parameter is an indicator of whether a given run is for test purposes or not, PROD vs. TEST.

This change is part of providing a DUNE.daq_test field in the file-transfer metadata that we send to offline.  It will indicate whether the run was just a test (and therefore the data may not need to be persisted for a long time by the offline).

This PR is part of a Deliverable for fddaq-v4.4.0, DUNE-DAQ/daq-deliverables#126.