### PR TITLE
Porting v4 changes to v5 - Added a field to the StartParams schema

### DIFF
--- a/schema/rcif/cmd.jsonnet
+++ b/schema/rcif/cmd.jsonnet
@@ -39,7 +39,8 @@ local cs = {
     start_params: s.record("StartParams", [
         s.field("run", self.run_number, doc="Run Number"),
         s.field("disable_data_storage", self.disable_storage, 0, doc="Bool to disable storage. True = storage disabled"),
-        s.field("trigger_rate", self.trg_rate, doc="Generated fake trigger rate Hz.", optional=true)
+        s.field("trigger_rate", self.trg_rate, doc="Generated fake trigger rate Hz.", optional=true),
+        s.field("production_vs_test", self.state, "TEST", doc="Indicator of Production vs. Test running.")
     ]),
 
     change_rate_params: s.record("ChangeRateParams", [


### PR DESCRIPTION
The goal of this Pull Request is to bring changes that were only made in the v4 line of development into the v5 line.

In this repo (rcif), the only change that was made on the v4 line after v5 work started was the addition of a run-start parameter that indicates whether a run is for test purposes or not, PROD vs. TEST

It would be great for someone familiar with the run control changes made in v5 to indicate whether this change is relevant for v5 or not.  And, if it is, to verify that the RC code in v5 works correctly with this change.