### PR TITLE
Cherry-picked the v4 cmd.jsonnet schema change that added the product…

### DIFF
--- a/schema/rcif/cmd.jsonnet
+++ b/schema/rcif/cmd.jsonnet
@@ -39,7 +39,8 @@ local cs = {
     start_params: s.record("StartParams", [
         s.field("run", self.run_number, doc="Run Number"),
         s.field("disable_data_storage", self.disable_storage, 0, doc="Bool to disable storage. True = storage disabled"),
-        s.field("trigger_rate", self.trg_rate, doc="Generated fake trigger rate Hz.", optional=true)
+        s.field("trigger_rate", self.trg_rate, doc="Generated fake trigger rate Hz.", optional=true),
+        s.field("production_vs_test", self.state, "TEST", doc="Indicator of Production vs. Test running.")
     ]),
 
     change_rate_params: s.record("ChangeRateParams", [


### PR DESCRIPTION
…ion_vs_test start command parameter.

This parameter is used to pass the user choice of PROD or TEST down to the data-writing software so that it can indicate that choice in an HDF5 file Attribute.  

This change is part of a wider set that includes one in dfmodules (https://github.com/DUNE-DAQ/dfmodules/pull/383) and can generally be described as porting HDF5 Attribute changes from v4 to v5.